### PR TITLE
refactor: introduce port layer for user repository

### DIFF
--- a/api/proto/user/user.proto
+++ b/api/proto/user/user.proto
@@ -1,7 +1,7 @@
 ﻿syntax = "proto3";
 
 package money_transfer.user_service;
-option go_package = "github.com/bqdanh/stock-trading-be";
+option go_package = "github.com/sinhnguyen1411/stock-trading-be";
 
 import "validate/validate.proto";
 import "google/api/annotations.proto";

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,7 +2,7 @@ version: v1
 managed:
   enabled: true
   go_package_prefix:
-    default: github.com/bqdanh/stock-trading-be/api
+    default: github.com/sinhnguyen1411/stock-trading-be/api
     except:
       - buf.build/grpc-ecosystem/protoc-gen-swagger
       - buf.build/grpc-ecosystem/openapiv2

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/bqdanh/stock-trading-be/cmd/server"
+	"github.com/sinhnguyen1411/stock-trading-be/cmd/server"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/server/config/config.go
+++ b/cmd/server/config/config.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bqdanh/stock-trading-be/internal/adapters/server/grpc_server"
-	"github.com/bqdanh/stock-trading-be/internal/adapters/server/http_gateway"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/grpc_server"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/http_gateway"
 	"github.com/spf13/viper"
 )
 

--- a/cmd/server/dependencies.go
+++ b/cmd/server/dependencies.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"database/sql"
-	"github.com/bqdanh/stock-trading-be/cmd/server/config"
+	"github.com/sinhnguyen1411/stock-trading-be/cmd/server/config"
 )
 
 type InfrastructureDependencies struct {

--- a/cmd/server/grpc_server.go
+++ b/cmd/server/grpc_server.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"fmt"
-	"github.com/bqdanh/stock-trading-be/cmd/server/config"
-	"github.com/bqdanh/stock-trading-be/internal/adapters/database"
-	use_case "github.com/bqdanh/stock-trading-be/internal/usecases/user"
+	"github.com/sinhnguyen1411/stock-trading-be/cmd/server/config"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/database"
+	use_case "github.com/sinhnguyen1411/stock-trading-be/internal/usecases/user"
 
-	grpcadapter "github.com/bqdanh/stock-trading-be/internal/adapters/server/grpc_server"
-	"github.com/bqdanh/stock-trading-be/internal/adapters/server/grpc_server/users"
+	grpcadapter "github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/grpc_server"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/grpc_server/users"
 )
 
 func NewGrpcServices(cfg config.Config, infra *InfrastructureDependencies, adapters *Adapters) ([]grpcadapter.Service, error) {

--- a/cmd/server/http_server.go
+++ b/cmd/server/http_server.go
@@ -2,10 +2,10 @@ package server
 
 import (
 	"fmt"
-	"github.com/bqdanh/stock-trading-be/cmd/server/config"
+	"github.com/sinhnguyen1411/stock-trading-be/cmd/server/config"
 
-	"github.com/bqdanh/stock-trading-be/internal/adapters/server/http_gateway"
-	usersgw "github.com/bqdanh/stock-trading-be/internal/adapters/server/http_gateway/users"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/http_gateway"
+	usersgw "github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/http_gateway/users"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,14 +3,14 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/bqdanh/stock-trading-be/cmd/server/config"
+	"github.com/sinhnguyen1411/stock-trading-be/cmd/server/config"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
-	grpcadapter "github.com/bqdanh/stock-trading-be/internal/adapters/server/grpc_server"
-	"github.com/bqdanh/stock-trading-be/internal/adapters/server/http_gateway"
+	grpcadapter "github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/grpc_server"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/http_gateway"
 	"github.com/urfave/cli/v2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bqdanh/stock-trading-be
+module github.com/sinhnguyen1411/stock-trading-be
 
 go 1.23.2
 

--- a/internal/adapters/database/inmemory_repository.go
+++ b/internal/adapters/database/inmemory_repository.go
@@ -1,12 +1,14 @@
-﻿package database
+package database
 
 import (
 	"context"
-	"github.com/bqdanh/stock-trading-be/internal/entities/user"
+	userentity "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
 )
 
-type InMemoryUserRepository struct {
-}
+type InMemoryUserRepository struct{}
+
+var _ ports.UserRepository = InMemoryUserRepository{}
 
 // CheckUserNameAndEmailIsExist check username and email is existed in system
 func (r InMemoryUserRepository) CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error {
@@ -14,6 +16,6 @@ func (r InMemoryUserRepository) CheckUserNameAndEmailIsExist(ctx context.Context
 }
 
 // InsertRegisterInfo insert into repository and then generate userID
-func (r InMemoryUserRepository) InsertRegisterInfo(ctx context.Context, user user.User, loginMethod user.LoginMethodPassword) error {
+func (r InMemoryUserRepository) InsertRegisterInfo(ctx context.Context, user userentity.User, loginMethod userentity.LoginMethodPassword) error {
 	return nil
 }

--- a/internal/adapters/database/mysql.go
+++ b/internal/adapters/database/mysql.go
@@ -1,10 +1,11 @@
-﻿package database
+package database
 
 import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/bqdanh/stock-trading-be/internal/entities/user"
+	userentity "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
 	_ "github.com/go-sql-driver/mysql"
 )
 
@@ -27,8 +28,9 @@ func ConnectDB() {
 	fmt.Println("✅ Kết nối thành công MySQL")
 }
 
-type MysqlUserRepository struct {
-}
+type MysqlUserRepository struct{}
+
+var _ ports.UserRepository = MysqlUserRepository{}
 
 func NewMysqlUserRepository() MysqlUserRepository {
 	return MysqlUserRepository{}
@@ -40,7 +42,7 @@ func (r MysqlUserRepository) CheckUserNameAndEmailIsExist(ctx context.Context, u
 }
 
 // InsertRegisterInfo insert into repository and then generate userID
-func (r MysqlUserRepository) InsertRegisterInfo(ctx context.Context, user user.User, loginMethod user.LoginMethodPassword) error {
+func (r MysqlUserRepository) InsertRegisterInfo(ctx context.Context, user userentity.User, loginMethod userentity.LoginMethodPassword) error {
 	//_, err := DB.Exec("INSERT INTO users (username, password_hash, email) VALUES (?, ?, ?)", loginMethod.UserName, loginMethod.Password, user.Email)
 	gender := "female"
 	if user.Gender == true {

--- a/internal/adapters/server/grpc_server/users/login.go
+++ b/internal/adapters/server/grpc_server/users/login.go
@@ -2,7 +2,7 @@
 
 import (
 	"context"
-	"github.com/bqdanh/stock-trading-be/api/grpc/user"
+	"github.com/sinhnguyen1411/stock-trading-be/api/grpc/user"
 	"google.golang.org/grpc/codes"
 )
 

--- a/internal/adapters/server/grpc_server/users/service.go
+++ b/internal/adapters/server/grpc_server/users/service.go
@@ -2,8 +2,8 @@ package users
 
 import (
 	"context"
-	"github.com/bqdanh/stock-trading-be/api/grpc/user"
-	user2 "github.com/bqdanh/stock-trading-be/internal/usecases/user"
+	"github.com/sinhnguyen1411/stock-trading-be/api/grpc/user"
+	user2 "github.com/sinhnguyen1411/stock-trading-be/internal/usecases/user"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/internal/adapters/server/http_gateway/users/service.go
+++ b/internal/adapters/server/http_gateway/users/service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/bqdanh/stock-trading-be/api/grpc/user"
+	"github.com/sinhnguyen1411/stock-trading-be/api/grpc/user"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 )

--- a/internal/ports/user_repository.go
+++ b/internal/ports/user_repository.go
@@ -1,0 +1,14 @@
+package ports
+
+import (
+	"context"
+	user "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
+)
+
+// UserRepository defines the interface for user persistence operations.
+type UserRepository interface {
+	// CheckUserNameAndEmailIsExist checks username and email are not already present in repository.
+	CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error
+	// InsertRegisterInfo persists a new user and login method.
+	InsertRegisterInfo(ctx context.Context, user user.User, loginMethod user.LoginMethodPassword) error
+}

--- a/internal/usecases/user/register.go
+++ b/internal/usecases/user/register.go
@@ -1,29 +1,22 @@
-﻿package user
+package user
 
 import (
 	"context"
 	"fmt"
-	"github.com/bqdanh/stock-trading-be/internal/entities/user"
+	userentity "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
 	"golang.org/x/crypto/bcrypt"
 	"time"
 )
 
 type UserRegisterUseCase struct {
-	repository UserRepository
+	repository ports.UserRepository
 }
 
-func NewUserRegisterUseCase(repo UserRepository) UserRegisterUseCase {
+func NewUserRegisterUseCase(repo ports.UserRepository) UserRegisterUseCase {
 	return UserRegisterUseCase{
 		repository: repo,
 	}
-}
-
-// UserRepository port layer
-type UserRepository interface {
-	//CheckUserNameAndEmailIsExist check username and email is existed in system
-	CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error
-	//InsertRegisterInfo insert into repository and then generate userID
-	InsertRegisterInfo(ctx context.Context, user user.User, loginMethod user.LoginMethodPassword) error
 }
 
 type RequestRegister struct {
@@ -59,7 +52,7 @@ func (u UserRegisterUseCase) RegisterAccount(ctx context.Context, req RequestReg
 		return fmt.Errorf("hash password got error: %w", err)
 	}
 
-	usermodel := user.User{
+	usermodel := userentity.User{
 		Id:               0, //insert into database will create userID
 		Name:             req.Name,
 		Email:            req.Email,
@@ -69,7 +62,7 @@ func (u UserRegisterUseCase) RegisterAccount(ctx context.Context, req RequestReg
 		PermanentAddress: req.PermanentAddress,
 		PhoneNumber:      req.PhoneNumber,
 	}
-	loginMethod := user.LoginMethodPassword{
+	loginMethod := userentity.LoginMethodPassword{
 		UserName: req.Username,
 		Password: string(hashedPassword),
 	}

--- a/internal/usecases/user/register_test.go
+++ b/internal/usecases/user/register_test.go
@@ -1,25 +1,22 @@
-﻿package user
+package user
 
 import (
-	"github.com/bqdanh/stock-trading-be/internal/entities/user"
+	"context"
+	userentity "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-import (
-	"context"
-)
+type InMemoryUserRepository struct{}
 
-type InMemoryUserRepository struct {
-}
+var _ ports.UserRepository = InMemoryUserRepository{}
 
-// CheckUserNameAndEmailIsExist check username and email is existed in system
 func (r InMemoryUserRepository) CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error {
 	return nil
 }
 
-// InsertRegisterInfo insert into repository and then generate userID
-func (r InMemoryUserRepository) InsertRegisterInfo(ctx context.Context, user user.User, loginMethod user.LoginMethodPassword) error {
+func (r InMemoryUserRepository) InsertRegisterInfo(ctx context.Context, user userentity.User, loginMethod userentity.LoginMethodPassword) error {
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 ﻿package main
 
 import (
-	"github.com/bqdanh/stock-trading-be/cmd"
+	"github.com/sinhnguyen1411/stock-trading-be/cmd"
 	"os"
 )
 


### PR DESCRIPTION
## Summary
- add ports.UserRepository interface to isolate domain from adapters
- update user registration use case to depend on port layer
- implement new port in MySQL and in-memory repositories and adjust tests
- update module path and imports to github.com/sinhnguyen1411/stock-trading-be

## Testing
- `go mod tidy` *(fails: Forbidden)*
- `go test ./...`
