### PR TITLE
feat: add configurable DB and login use case

### DIFF
--- a/cmd/server/config/config.go
+++ b/cmd/server/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/database"
 	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/grpc_server"
 	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/http_gateway"
 	"github.com/spf13/viper"
@@ -15,6 +16,7 @@ type Config struct {
 	Env  string              `json:"env" mapstructure:"env"`
 	GRPC grpc_server.Config  `json:"grpc" mapstructure:"grpc"`
 	HTTP http_gateway.Config `json:"http" mapstructure:"http"`
+	DB   database.Config     `json:"db" mapstructure:"db"`
 }
 
 func loadDefaultConfig() *Config {
@@ -28,6 +30,13 @@ func loadDefaultConfig() *Config {
 			Host: "0.0.0.0",
 			Port: 8080,
 		},
+		DB: database.Config{
+			Host:     "127.0.0.1",
+			Port:     3306,
+			User:     "stock_user",
+			Password: "ps123456",
+			Name:     "stock",
+		},
 	}
 }
 
@@ -37,11 +46,11 @@ func LoadConfig(configPath string) (*Config, error) {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "__"))
 	viper.AutomaticEnv()
 	/**
-	|-------------------------------------------------------------------------
-	| You should set default config value here
-	| 1. Populate the default value in (Source code)
-	| 2. Then merge from config (YAML) and OS environment
-	|-----------------------------------------------------------------------*/
+	  |-------------------------------------------------------------------------
+	  | You should set default config value here
+	  | 1. Populate the default value in (Source code)
+	  | 2. Then merge from config (YAML) and OS environment
+	  |-----------------------------------------------------------------------*/
 	// Load default config
 	c := loadDefaultConfig()
 	configBuffer, err := json.Marshal(c)

--- a/cmd/server/grpc_server.go
+++ b/cmd/server/grpc_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+
 	"github.com/sinhnguyen1411/stock-trading-be/cmd/server/config"
 	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/database"
 	use_case "github.com/sinhnguyen1411/stock-trading-be/internal/usecases/user"
@@ -21,10 +22,12 @@ func NewGrpcServices(cfg config.Config, infra *InfrastructureDependencies, adapt
 	}, nil
 }
 
-func NewUserService(_ config.Config, _ *InfrastructureDependencies, adapters *Adapters) (*users.UserService, error) {
-	database.ConnectDB()
-	userUseCase := use_case.NewUserRegisterUseCase(database.NewMysqlUserRepository())
+func NewUserService(cfg config.Config, _ *InfrastructureDependencies, adapters *Adapters) (*users.UserService, error) {
+	database.ConnectDB(cfg.DB)
+	repo := database.NewMysqlUserRepository()
+	userUseCase := use_case.NewUserRegisterUseCase(repo)
+	loginUseCase := use_case.NewUserLoginUseCase(repo)
 
-	userService := users.NewUserService(userUseCase)
+	userService := users.NewUserService(userUseCase, loginUseCase)
 	return userService, nil
 }

--- a/internal/adapters/database/config.go
+++ b/internal/adapters/database/config.go
@@ -1,0 +1,10 @@
+package database
+
+// Config holds the database connection configuration.
+type Config struct {
+	Host     string `json:"host" mapstructure:"host"`
+	Port     int    `json:"port" mapstructure:"port"`
+	User     string `json:"user" mapstructure:"user"`
+	Password string `json:"password" mapstructure:"password"`
+	Name     string `json:"name" mapstructure:"name"`
+}

--- a/internal/adapters/database/inmemory_repository.go
+++ b/internal/adapters/database/inmemory_repository.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"context"
+	"fmt"
+
 	userentity "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
 	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
 )
@@ -13,6 +15,11 @@ var _ ports.UserRepository = InMemoryUserRepository{}
 // CheckUserNameAndEmailIsExist check username and email is existed in system
 func (r InMemoryUserRepository) CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error {
 	return nil
+}
+
+// GetLoginInfo returns login information for given username
+func (r InMemoryUserRepository) GetLoginInfo(ctx context.Context, userName string) (userentity.LoginMethodPassword, error) {
+	return userentity.LoginMethodPassword{}, fmt.Errorf("not implemented")
 }
 
 // InsertRegisterInfo insert into repository and then generate userID

--- a/internal/adapters/database/mysql.go
+++ b/internal/adapters/database/mysql.go
@@ -4,23 +4,25 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	_ "github.com/go-sql-driver/mysql"
 	userentity "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
 	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
-	_ "github.com/go-sql-driver/mysql"
 )
 
 var DB *sql.DB
 
-func ConnectDB() {
+// ConnectDB initialises the global DB connection using provided configuration.
+func ConnectDB(cfg Config) {
 	var err error
-	DB, err = sql.Open("mysql", "stock_user:ps123456@tcp(127.0.0.1:3306)/stock")
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Name)
+	DB, err = sql.Open("mysql", dsn)
 	if err != nil {
 		fmt.Println("❌ Không thể kết nối MySQL:", err)
 		return
 	}
 
-	err = DB.Ping()
-	if err != nil {
+	if err = DB.Ping(); err != nil {
 		fmt.Println("❌ MySQL không phản hồi:", err)
 		return
 	}
@@ -38,17 +40,36 @@ func NewMysqlUserRepository() MysqlUserRepository {
 
 // CheckUserNameAndEmailIsExist check username and email is existed in system
 func (r MysqlUserRepository) CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error {
+	var count int
+	err := DB.QueryRowContext(ctx, "SELECT COUNT(*) FROM stock.users WHERE username = ? OR email = ?", userName, email).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("query username/email exists failed: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf("username or email already exists")
+	}
 	return nil
+}
+
+// GetLoginInfo returns login information for given username
+func (r MysqlUserRepository) GetLoginInfo(ctx context.Context, userName string) (userentity.LoginMethodPassword, error) {
+	var login userentity.LoginMethodPassword
+	err := DB.QueryRowContext(ctx, "SELECT username, password_hash FROM stock.users WHERE username = ?", userName).Scan(&login.UserName, &login.Password)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return login, fmt.Errorf("user not found")
+		}
+		return login, fmt.Errorf("query login info failed: %w", err)
+	}
+	return login, nil
 }
 
 // InsertRegisterInfo insert into repository and then generate userID
 func (r MysqlUserRepository) InsertRegisterInfo(ctx context.Context, user userentity.User, loginMethod userentity.LoginMethodPassword) error {
-	//_, err := DB.Exec("INSERT INTO users (username, password_hash, email) VALUES (?, ?, ?)", loginMethod.UserName, loginMethod.Password, user.Email)
 	gender := "female"
 	if user.Gender == true {
 		gender = "male"
 	}
-	//TODO: move user name and password to table loginMethods
 	_, err := DB.Exec("INSERT INTO stock.users (name, cmnd, birthday, gender, permanent_address, phone_number, username, password_hash, email) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
 		user.Name, user.DocumentID, user.Birthday, gender, user.PermanentAddress, user.PhoneNumber, loginMethod.UserName, loginMethod.Password, user.Email)
 	if err != nil {

--- a/internal/adapters/server/grpc_server/users/login.go
+++ b/internal/adapters/server/grpc_server/users/login.go
@@ -1,16 +1,21 @@
-﻿package users
+package users
 
 import (
 	"context"
+
 	"github.com/sinhnguyen1411/stock-trading-be/api/grpc/user"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *UserService) Login(ctx context.Context, req *user.LoginRequest) (*user.LoginResponse, error) {
-	//do something
+	token, err := s.loginUseCase.Login(ctx, req.Username, req.Password)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "login failed: %v", err)
+	}
 	return &user.LoginResponse{
 		Code:    uint32(codes.OK),
 		Message: codes.OK.String(),
-		Data:    &user.LoginResponse_Data{Token: "bandan"},
+		Data:    &user.LoginResponse_Data{Token: token},
 	}, nil
 }

--- a/internal/adapters/server/grpc_server/users/service.go
+++ b/internal/adapters/server/grpc_server/users/service.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"context"
+
 	"github.com/sinhnguyen1411/stock-trading-be/api/grpc/user"
 	user2 "github.com/sinhnguyen1411/stock-trading-be/internal/usecases/user"
 	"google.golang.org/grpc"
@@ -11,14 +12,17 @@ import (
 
 type UserService struct {
 	user.UnimplementedUserServiceServer
-	userUseCase user2.UserRegisterUseCase
+	userUseCase  user2.UserRegisterUseCase
+	loginUseCase user2.UserLoginUseCase
 }
 
 func NewUserService(
 	registerUseCase user2.UserRegisterUseCase,
+	loginUseCase user2.UserLoginUseCase,
 ) *UserService {
 	return &UserService{
-		userUseCase: registerUseCase,
+		userUseCase:  registerUseCase,
+		loginUseCase: loginUseCase,
 	}
 }
 

--- a/internal/ports/user_repository.go
+++ b/internal/ports/user_repository.go
@@ -2,6 +2,7 @@ package ports
 
 import (
 	"context"
+
 	user "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
 )
 
@@ -11,4 +12,6 @@ type UserRepository interface {
 	CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error
 	// InsertRegisterInfo persists a new user and login method.
 	InsertRegisterInfo(ctx context.Context, user user.User, loginMethod user.LoginMethodPassword) error
+	// GetLoginInfo retrieves login information for a username.
+	GetLoginInfo(ctx context.Context, userName string) (user.LoginMethodPassword, error)
 }

--- a/internal/usecases/user/login.go
+++ b/internal/usecases/user/login.go
@@ -1,0 +1,43 @@
+package user
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type UserLoginUseCase struct {
+	repository ports.UserRepository
+}
+
+func NewUserLoginUseCase(repo ports.UserRepository) UserLoginUseCase {
+	return UserLoginUseCase{repository: repo}
+}
+
+// Login validates user credentials and returns a token when successful.
+func (u UserLoginUseCase) Login(ctx context.Context, username, password string) (string, error) {
+	info, err := u.repository.GetLoginInfo(ctx, username)
+	if err != nil {
+		return "", fmt.Errorf("get login info: %w", err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(info.Password), []byte(password)); err != nil {
+		return "", fmt.Errorf("invalid credentials")
+	}
+	token, err := generateToken()
+	if err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	return token, nil
+}
+
+func generateToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}

--- a/internal/usecases/user/login_test.go
+++ b/internal/usecases/user/login_test.go
@@ -1,0 +1,41 @@
+package user
+
+import (
+	"context"
+	"testing"
+
+	userentity "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type loginRepo struct {
+	hash string
+}
+
+var _ ports.UserRepository = loginRepo{}
+
+func (r loginRepo) CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error {
+	return nil
+}
+func (r loginRepo) InsertRegisterInfo(ctx context.Context, user userentity.User, loginMethod userentity.LoginMethodPassword) error {
+	return nil
+}
+func (r loginRepo) GetLoginInfo(ctx context.Context, userName string) (userentity.LoginMethodPassword, error) {
+	return userentity.LoginMethodPassword{UserName: userName, Password: r.hash}, nil
+}
+
+func TestLogin(t *testing.T) {
+	pw := "secret"
+	hashed, _ := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost)
+	repo := loginRepo{hash: string(hashed)}
+	uc := NewUserLoginUseCase(repo)
+
+	token, err := uc.Login(context.Background(), "alice", pw)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, token)
+
+	_, err = uc.Login(context.Background(), "alice", "wrong")
+	assert.Error(t, err)
+}

--- a/internal/usecases/user/register_test.go
+++ b/internal/usecases/user/register_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	userentity "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
@@ -19,6 +20,10 @@ func (r InMemoryUserRepository) CheckUserNameAndEmailIsExist(ctx context.Context
 
 func (r InMemoryUserRepository) InsertRegisterInfo(ctx context.Context, user userentity.User, loginMethod userentity.LoginMethodPassword) error {
 	return nil
+}
+
+func (r InMemoryUserRepository) GetLoginInfo(ctx context.Context, userName string) (userentity.LoginMethodPassword, error) {
+	return userentity.LoginMethodPassword{}, fmt.Errorf("not implemented")
 }
 
 func TestRegister(t *testing.T) {


### PR DESCRIPTION
## Summary
- load MySQL connection settings from config/env instead of hard-coded DSN
- validate duplicate usernames/emails and support credential lookup
- implement login use case and gRPC handler returning token

## Testing
- `go test ./... -v`
