### PR TITLE
feat: add delete user API

### DIFF
--- a/api/grpc/user/delete.pb.go
+++ b/api/grpc/user/delete.pb.go
@@ -1,0 +1,96 @@
+// Code generated manually for Delete user messages.
+// This is a simplified placeholder and may not contain full descriptor info.
+package user
+
+import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+)
+
+type DeleteRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+}
+
+func (x *DeleteRequest) Reset()         { *x = DeleteRequest{} }
+func (x *DeleteRequest) String() string { return protoimpl.X.MessageStringOf(x) }
+func (*DeleteRequest) ProtoMessage()    {}
+
+var deleteRequestMessageInfo = protoimpl.MessageInfo{
+	GoReflectType: reflect.TypeOf((*DeleteRequest)(nil)).Elem(),
+}
+
+func (x *DeleteRequest) ProtoReflect() protoreflect.Message {
+	mi := &deleteRequestMessageInfo
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (*DeleteRequest) Descriptor() ([]byte, []int) { return nil, []int{} }
+
+func (x *DeleteRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+type DeleteResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Code    uint32 `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
+	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+}
+
+func (x *DeleteResponse) Reset()         { *x = DeleteResponse{} }
+func (x *DeleteResponse) String() string { return protoimpl.X.MessageStringOf(x) }
+func (*DeleteResponse) ProtoMessage()    {}
+
+var deleteResponseMessageInfo = protoimpl.MessageInfo{
+	GoReflectType: reflect.TypeOf((*DeleteResponse)(nil)).Elem(),
+}
+
+func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
+	mi := &deleteResponseMessageInfo
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (*DeleteResponse) Descriptor() ([]byte, []int) { return nil, []int{} }
+
+func (x *DeleteResponse) GetCode() uint32 {
+	if x != nil {
+		return x.Code
+	}
+	return 0
+}
+
+func (x *DeleteResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+var (
+	_ sync.Mutex // to avoid unused import errors with sync
+)

--- a/api/grpc/user/user_grpc.pb.go
+++ b/api/grpc/user/user_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	UserService_Register_FullMethodName = "/money_transfer.user_service.UserService/Register"
 	UserService_Login_FullMethodName    = "/money_transfer.user_service.UserService/Login"
+	UserService_Delete_FullMethodName   = "/money_transfer.user_service.UserService/Delete"
 )
 
 // UserServiceClient is the client API for UserService service.
@@ -29,6 +30,7 @@ const (
 type UserServiceClient interface {
 	Register(ctx context.Context, in *RegisterRequest, opts ...grpc.CallOption) (*RegisterResponse, error)
 	Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error)
+	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*DeleteResponse, error)
 }
 
 type userServiceClient struct {
@@ -59,12 +61,23 @@ func (c *userServiceClient) Login(ctx context.Context, in *LoginRequest, opts ..
 	return out, nil
 }
 
+func (c *userServiceClient) Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*DeleteResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteResponse)
+	err := c.cc.Invoke(ctx, UserService_Delete_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // UserServiceServer is the server API for UserService service.
 // All implementations must embed UnimplementedUserServiceServer
 // for forward compatibility.
 type UserServiceServer interface {
 	Register(context.Context, *RegisterRequest) (*RegisterResponse, error)
 	Login(context.Context, *LoginRequest) (*LoginResponse, error)
+	Delete(context.Context, *DeleteRequest) (*DeleteResponse, error)
 	mustEmbedUnimplementedUserServiceServer()
 }
 
@@ -80,6 +93,9 @@ func (UnimplementedUserServiceServer) Register(context.Context, *RegisterRequest
 }
 func (UnimplementedUserServiceServer) Login(context.Context, *LoginRequest) (*LoginResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Login not implemented")
+}
+func (UnimplementedUserServiceServer) Delete(context.Context, *DeleteRequest) (*DeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
 }
 func (UnimplementedUserServiceServer) mustEmbedUnimplementedUserServiceServer() {}
 func (UnimplementedUserServiceServer) testEmbeddedByValue()                     {}
@@ -138,6 +154,24 @@ func _UserService_Login_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _UserService_Delete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserServiceServer).Delete(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserService_Delete_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserServiceServer).Delete(ctx, req.(*DeleteRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // UserService_ServiceDesc is the grpc.ServiceDesc for UserService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -152,6 +186,10 @@ var UserService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Login",
 			Handler:    _UserService_Login_Handler,
+		},
+		{
+			MethodName: "Delete",
+			Handler:    _UserService_Delete_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/proto/user/user.proto
+++ b/api/proto/user/user.proto
@@ -23,6 +23,12 @@ service UserService {
       body: "*"
     };
   }
+
+  rpc Delete(DeleteRequest) returns (DeleteResponse) {
+    option (google.api.http) = {
+      delete: "/api/v1/user/{username}"
+    };
+  }
 }
 
 
@@ -58,4 +64,13 @@ message LoginResponse {
   }
 
   Data data = 3;
+}
+
+message DeleteRequest {
+  string username = 1 [(validate.rules).string = {min_len: 6, max_len: 16}];
+}
+
+message DeleteResponse {
+  uint32 code = 1;
+  string message = 2;
 }

--- a/cmd/server/grpc_server.go
+++ b/cmd/server/grpc_server.go
@@ -27,7 +27,8 @@ func NewUserService(cfg config.Config, _ *InfrastructureDependencies, adapters *
 	repo := database.NewMysqlUserRepository()
 	userUseCase := use_case.NewUserRegisterUseCase(repo)
 	loginUseCase := use_case.NewUserLoginUseCase(repo)
+	deleteUseCase := use_case.NewUserDeleteUseCase(repo)
 
-	userService := users.NewUserService(userUseCase, loginUseCase)
+	userService := users.NewUserService(userUseCase, loginUseCase, deleteUseCase)
 	return userService, nil
 }

--- a/internal/adapters/database/inmemory_repository.go
+++ b/internal/adapters/database/inmemory_repository.go
@@ -26,3 +26,8 @@ func (r InMemoryUserRepository) GetLoginInfo(ctx context.Context, userName strin
 func (r InMemoryUserRepository) InsertRegisterInfo(ctx context.Context, user userentity.User, loginMethod userentity.LoginMethodPassword) error {
 	return nil
 }
+
+// DeleteUser removes a user from the in-memory repository.
+func (r InMemoryUserRepository) DeleteUser(ctx context.Context, userName string) error {
+	return nil
+}

--- a/internal/adapters/database/mysql.go
+++ b/internal/adapters/database/mysql.go
@@ -77,3 +77,12 @@ func (r MysqlUserRepository) InsertRegisterInfo(ctx context.Context, user useren
 	}
 	return nil
 }
+
+// DeleteUser removes a user by username from MySQL repository.
+func (r MysqlUserRepository) DeleteUser(ctx context.Context, userName string) error {
+	_, err := DB.ExecContext(ctx, "DELETE FROM stock.users WHERE username = ?", userName)
+	if err != nil {
+		return fmt.Errorf("delete user failed: %w", err)
+	}
+	return nil
+}

--- a/internal/adapters/server/grpc_server/users/delete.go
+++ b/internal/adapters/server/grpc_server/users/delete.go
@@ -1,0 +1,19 @@
+package users
+
+import (
+	"context"
+
+	"github.com/sinhnguyen1411/stock-trading-be/api/grpc/user"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *UserService) Delete(ctx context.Context, req *user.DeleteRequest) (*user.DeleteResponse, error) {
+	if err := s.deleteUseCase.DeleteAccount(ctx, req.Username); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete account: %v", err)
+	}
+	return &user.DeleteResponse{
+		Code:    uint32(codes.OK),
+		Message: codes.OK.String(),
+	}, nil
+}

--- a/internal/adapters/server/grpc_server/users/service.go
+++ b/internal/adapters/server/grpc_server/users/service.go
@@ -12,17 +12,20 @@ import (
 
 type UserService struct {
 	user.UnimplementedUserServiceServer
-	userUseCase  user2.UserRegisterUseCase
-	loginUseCase user2.UserLoginUseCase
+	userUseCase   user2.UserRegisterUseCase
+	loginUseCase  user2.UserLoginUseCase
+	deleteUseCase user2.UserDeleteUseCase
 }
 
 func NewUserService(
 	registerUseCase user2.UserRegisterUseCase,
 	loginUseCase user2.UserLoginUseCase,
+	deleteUseCase user2.UserDeleteUseCase,
 ) *UserService {
 	return &UserService{
-		userUseCase:  registerUseCase,
-		loginUseCase: loginUseCase,
+		userUseCase:   registerUseCase,
+		loginUseCase:  loginUseCase,
+		deleteUseCase: deleteUseCase,
 	}
 }
 

--- a/internal/ports/user_repository.go
+++ b/internal/ports/user_repository.go
@@ -14,4 +14,6 @@ type UserRepository interface {
 	InsertRegisterInfo(ctx context.Context, user user.User, loginMethod user.LoginMethodPassword) error
 	// GetLoginInfo retrieves login information for a username.
 	GetLoginInfo(ctx context.Context, userName string) (user.LoginMethodPassword, error)
+	// DeleteUser removes a user from repository by username.
+	DeleteUser(ctx context.Context, userName string) error
 }

--- a/internal/usecases/user/delete.go
+++ b/internal/usecases/user/delete.go
@@ -1,0 +1,26 @@
+package user
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
+)
+
+type UserDeleteUseCase struct {
+	repository ports.UserRepository
+}
+
+func NewUserDeleteUseCase(repo ports.UserRepository) UserDeleteUseCase {
+	return UserDeleteUseCase{repository: repo}
+}
+
+func (u UserDeleteUseCase) DeleteAccount(ctx context.Context, username string) error {
+	if username == "" {
+		return fmt.Errorf("username is empty")
+	}
+	if err := u.repository.DeleteUser(ctx, username); err != nil {
+		return fmt.Errorf("delete user got error: %w", err)
+	}
+	return nil
+}

--- a/internal/usecases/user/delete_test.go
+++ b/internal/usecases/user/delete_test.go
@@ -1,0 +1,46 @@
+package user
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	userentity "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
+	"github.com/stretchr/testify/assert"
+)
+
+type deleteRepo struct {
+	deleted string
+	err     error
+}
+
+var _ ports.UserRepository = &deleteRepo{}
+
+func (r *deleteRepo) CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error {
+	return nil
+}
+
+func (r *deleteRepo) InsertRegisterInfo(ctx context.Context, user userentity.User, loginMethod userentity.LoginMethodPassword) error {
+	return nil
+}
+
+func (r *deleteRepo) GetLoginInfo(ctx context.Context, userName string) (userentity.LoginMethodPassword, error) {
+	return userentity.LoginMethodPassword{}, fmt.Errorf("not implemented")
+}
+
+func (r *deleteRepo) DeleteUser(ctx context.Context, userName string) error {
+	r.deleted = userName
+	return r.err
+}
+
+func TestDeleteAccount(t *testing.T) {
+	repo := &deleteRepo{}
+	uc := NewUserDeleteUseCase(repo)
+	err := uc.DeleteAccount(context.Background(), "alice123")
+	assert.NoError(t, err)
+	assert.Equal(t, "alice123", repo.deleted)
+
+	err = uc.DeleteAccount(context.Background(), "")
+	assert.Error(t, err)
+}

--- a/internal/usecases/user/login_test.go
+++ b/internal/usecases/user/login_test.go
@@ -25,6 +25,7 @@ func (r loginRepo) InsertRegisterInfo(ctx context.Context, user userentity.User,
 func (r loginRepo) GetLoginInfo(ctx context.Context, userName string) (userentity.LoginMethodPassword, error) {
 	return userentity.LoginMethodPassword{UserName: userName, Password: r.hash}, nil
 }
+func (r loginRepo) DeleteUser(ctx context.Context, userName string) error { return nil }
 
 func TestLogin(t *testing.T) {
 	pw := "secret"

--- a/internal/usecases/user/register_test.go
+++ b/internal/usecases/user/register_test.go
@@ -25,6 +25,7 @@ func (r InMemoryUserRepository) InsertRegisterInfo(ctx context.Context, user use
 func (r InMemoryUserRepository) GetLoginInfo(ctx context.Context, userName string) (userentity.LoginMethodPassword, error) {
 	return userentity.LoginMethodPassword{}, fmt.Errorf("not implemented")
 }
+func (r InMemoryUserRepository) DeleteUser(ctx context.Context, userName string) error { return nil }
 
 func TestRegister(t *testing.T) {
 	usecase := UserRegisterUseCase{


### PR DESCRIPTION
## Summary
- add Delete RPC and request/response models
- implement delete user use case and repository method
- wire delete API into gRPC user service

## Testing
- `go test ./...`