### PR TITLE
feat: allow running without mysql

### DIFF
--- a/cmd/server/grpc_server.go
+++ b/cmd/server/grpc_server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sinhnguyen1411/stock-trading-be/cmd/server/config"
 	"github.com/sinhnguyen1411/stock-trading-be/internal/adapters/database"
+	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
 	use_case "github.com/sinhnguyen1411/stock-trading-be/internal/usecases/user"
 
 	grpcadapter "github.com/sinhnguyen1411/stock-trading-be/internal/adapters/server/grpc_server"
@@ -23,8 +24,13 @@ func NewGrpcServices(cfg config.Config, infra *InfrastructureDependencies, adapt
 }
 
 func NewUserService(cfg config.Config, _ *InfrastructureDependencies, adapters *Adapters) (*users.UserService, error) {
-	database.ConnectDB(cfg.DB)
-	repo := database.NewMysqlUserRepository()
+	var repo ports.UserRepository
+	if err := database.ConnectDB(cfg.DB); err != nil {
+		repo = database.NewInMemoryUserRepository()
+	} else {
+		repo = database.NewMysqlUserRepository()
+	}
+
 	userUseCase := use_case.NewUserRegisterUseCase(repo)
 	loginUseCase := use_case.NewUserLoginUseCase(repo)
 	deleteUseCase := use_case.NewUserDeleteUseCase(repo)

--- a/cmd/server/http_server.go
+++ b/cmd/server/http_server.go
@@ -11,7 +11,11 @@ import (
 )
 
 func NewHTTPGatewayServices(cfg config.Config, _ *InfrastructureDependencies) ([]http_gateway.GrpcGatewayServices, error) {
-	grpcServerAddr := fmt.Sprintf("%s:%d", cfg.GRPC.Host, cfg.GRPC.Port)
+	grpcHost := cfg.GRPC.Host
+	if grpcHost == "0.0.0.0" {
+		grpcHost = "127.0.0.1"
+	}
+	grpcServerAddr := fmt.Sprintf("%s:%d", grpcHost, cfg.GRPC.Port)
 	grpcServerConn, err := grpc.NewClient(grpcServerAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(),

--- a/internal/adapters/database/inmemory_repository.go
+++ b/internal/adapters/database/inmemory_repository.go
@@ -3,31 +3,84 @@ package database
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	userentity "github.com/sinhnguyen1411/stock-trading-be/internal/entities/user"
 	"github.com/sinhnguyen1411/stock-trading-be/internal/ports"
 )
 
-type InMemoryUserRepository struct{}
+// InMemoryUserRepository provides a simple thread-safe in-memory implementation
+// of UserRepository. It is primarily used in local development or tests when a
+// real database is not available.
+type InMemoryUserRepository struct {
+	mu         sync.RWMutex
+	users      map[string]userentity.User
+	logins     map[string]userentity.LoginMethodPassword
+	emailIndex map[string]string // email -> username
+}
 
-var _ ports.UserRepository = InMemoryUserRepository{}
+var _ ports.UserRepository = (*InMemoryUserRepository)(nil)
 
-// CheckUserNameAndEmailIsExist check username and email is existed in system
-func (r InMemoryUserRepository) CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error {
+// NewInMemoryUserRepository creates a new instance of the repository.
+func NewInMemoryUserRepository() *InMemoryUserRepository {
+	return &InMemoryUserRepository{
+		users:      make(map[string]userentity.User),
+		logins:     make(map[string]userentity.LoginMethodPassword),
+		emailIndex: make(map[string]string),
+	}
+}
+
+// CheckUserNameAndEmailIsExist check username and email is existed in system.
+func (r *InMemoryUserRepository) CheckUserNameAndEmailIsExist(ctx context.Context, userName, email string) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if _, ok := r.users[userName]; ok {
+		return fmt.Errorf("username or email already exists")
+	}
+	if _, ok := r.emailIndex[email]; ok {
+		return fmt.Errorf("username or email already exists")
+	}
 	return nil
 }
 
-// GetLoginInfo returns login and user information for given username
-func (r InMemoryUserRepository) GetLoginInfo(ctx context.Context, userName string) (userentity.LoginMethodPassword, userentity.User, error) {
-	return userentity.LoginMethodPassword{}, userentity.User{}, fmt.Errorf("not implemented")
+// GetLoginInfo returns login and user information for given username.
+func (r *InMemoryUserRepository) GetLoginInfo(ctx context.Context, userName string) (userentity.LoginMethodPassword, userentity.User, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	login, ok1 := r.logins[userName]
+	user, ok2 := r.users[userName]
+	if !ok1 || !ok2 {
+		return userentity.LoginMethodPassword{}, userentity.User{}, fmt.Errorf("user not found")
+	}
+	return login, user, nil
 }
 
-// InsertRegisterInfo insert into repository and then generate userID
-func (r InMemoryUserRepository) InsertRegisterInfo(ctx context.Context, user userentity.User, loginMethod userentity.LoginMethodPassword) error {
+// InsertRegisterInfo insert into repository and then generate userID.
+func (r *InMemoryUserRepository) InsertRegisterInfo(ctx context.Context, user userentity.User, loginMethod userentity.LoginMethodPassword) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.users[loginMethod.UserName]; ok {
+		return fmt.Errorf("username or email already exists")
+	}
+	if _, ok := r.emailIndex[user.Email]; ok {
+		return fmt.Errorf("username or email already exists")
+	}
+	r.users[loginMethod.UserName] = user
+	r.logins[loginMethod.UserName] = loginMethod
+	r.emailIndex[user.Email] = loginMethod.UserName
 	return nil
 }
 
 // DeleteUser removes a user from the in-memory repository.
-func (r InMemoryUserRepository) DeleteUser(ctx context.Context, userName string) error {
+func (r *InMemoryUserRepository) DeleteUser(ctx context.Context, userName string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	user, ok := r.users[userName]
+	if !ok {
+		return fmt.Errorf("user not found")
+	}
+	delete(r.users, userName)
+	delete(r.logins, userName)
+	delete(r.emailIndex, user.Email)
 	return nil
 }

--- a/internal/adapters/database/mysql.go
+++ b/internal/adapters/database/mysql.go
@@ -13,21 +13,25 @@ import (
 var DB *sql.DB
 
 // ConnectDB initialises the global DB connection using provided configuration.
-func ConnectDB(cfg Config) {
+// It returns an error when the connection cannot be established so callers can
+// decide whether to fall back to another repository implementation (e.g.
+// in-memory) instead of relying on a nil DB object.
+func ConnectDB(cfg Config) error {
 	var err error
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Name)
 	DB, err = sql.Open("mysql", dsn)
 	if err != nil {
 		fmt.Println("❌ Không thể kết nối MySQL:", err)
-		return
+		return err
 	}
 
 	if err = DB.Ping(); err != nil {
 		fmt.Println("❌ MySQL không phản hồi:", err)
-		return
+		return err
 	}
 
 	fmt.Println("✅ Kết nối thành công MySQL")
+	return nil
 }
 
 type MysqlUserRepository struct{}


### PR DESCRIPTION
## Summary
- fallback to an in-memory user repository when MySQL is unavailable
- fix HTTP gateway gRPC dial address and provide thread-safe memory repo

## Testing
- `go test ./...`
- `go vet ./...`
